### PR TITLE
Address bug where README instructions run all tests

### DIFF
--- a/typescript-test-samples/typescript-test-intro/README.md
+++ b/typescript-test-samples/typescript-test-intro/README.md
@@ -113,7 +113,7 @@ typescript-test-intro$ cd list-buckets
 list-buckets$ npm install
 
 # run unit tests with mocks
-list-buckets$ npm test unit
+list-buckets$ npm run test:unit
 ```
 
 [[top]](#typescript-test-intro)
@@ -129,7 +129,7 @@ typescript-test-intro$ cd list-buckets
 # Set the environment variable API_URL to the base of the ListBucketsApi CloudFormation output from the deploy step above
 # E.g. https://aaaaaaaaaaa.execute-api.us-east-2.amazonaws.com/Prod
 # You can do this as a separate step if you prefer
-list-buckets$ API_URL=https://YOUR_API_URL npm test integration
+list-buckets$ API_URL=https://YOUR_API_URL npm run test:integration
 ```
 
 [[top]](#typescript-test-intro)

--- a/typescript-test-samples/typescript-test-intro/list-buckets/jest.config.ts
+++ b/typescript-test-samples/typescript-test-intro/list-buckets/jest.config.ts
@@ -4,6 +4,7 @@
  */
 
 export default {
+    projects: ['<rootDir>/jest.integration.config.ts', '<rootDir>/jest.unit.config.ts'],
     transform: {
         '^.+\\.ts?$': 'esbuild-jest',
     },

--- a/typescript-test-samples/typescript-test-intro/list-buckets/jest.integration.config.ts
+++ b/typescript-test-samples/typescript-test-intro/list-buckets/jest.integration.config.ts
@@ -1,0 +1,7 @@
+module.exports = {
+    displayName: 'integration',
+    testMatch: ['**/tests/integration/*.test.ts'],
+    transform: {
+        '^.+\\.ts?$': 'esbuild-jest',
+    },
+};

--- a/typescript-test-samples/typescript-test-intro/list-buckets/jest.unit.config.ts
+++ b/typescript-test-samples/typescript-test-intro/list-buckets/jest.unit.config.ts
@@ -1,0 +1,7 @@
+module.exports = {
+    displayName: 'unit',
+    testMatch: ['**/tests/unit/*.test.ts'],
+    transform: {
+        '^.+\\.ts?$': 'esbuild-jest',
+    },
+};

--- a/typescript-test-samples/typescript-test-intro/list-buckets/package.json
+++ b/typescript-test-samples/typescript-test-intro/list-buckets/package.json
@@ -11,10 +11,12 @@
     "esbuild": "^0.14.14"
   },
   "scripts": {
-    "unit": "jest",
     "lint": "eslint '*.ts' --quiet --fix",
     "compile": "tsc",
-    "test": "npm run compile && npm run unit"
+
+    "test": "npm run compile && jest",
+    "test:unit": "npm run compile && jest --selectProjects unit",
+    "test:integration": "npm run compile && jest --selectProjects integration"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.92",

--- a/typescript-test-samples/typescript-test-intro/list-buckets/package.json
+++ b/typescript-test-samples/typescript-test-intro/list-buckets/package.json
@@ -14,9 +14,9 @@
     "lint": "eslint '*.ts' --quiet --fix",
     "compile": "tsc",
 
-    "test": "npm run compile && jest",
-    "test:unit": "npm run compile && jest --selectProjects unit",
-    "test:integration": "npm run compile && jest --selectProjects integration"
+    "test": "jest",
+    "test:unit": "jest --selectProjects unit",
+    "test:integration": "jest --selectProjects integration"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.92",


### PR DESCRIPTION
README had the wrong test commands to run to trigger _just_ unit or _just_ integration tests. Pull in the same project-based config as the APIGW example and update README commands to match.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
