### PR TITLE
Turn on Jest silent mode via config.

### DIFF
--- a/typescript-test-samples/typescript-test-intro/list-buckets/jest.config.ts
+++ b/typescript-test-samples/typescript-test-intro/list-buckets/jest.config.ts
@@ -12,5 +12,6 @@ export default {
     collectCoverage: true,
     coverageDirectory: 'coverage',
     coverageProvider: 'v8',
+    silent: true,
     testMatch: ['**/tests/unit/*.test.ts', '**/tests/integration/*.test.ts'],
 };


### PR DESCRIPTION
Closes #78 

*Description of changes:*
Suppress console log output to avoid confusing users on initial runs of unit tests. Although some tests result in errors being printed to the console log, this is expected and not an indication that the test failed. In fact, the tests are checking that error paths execute correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
