### PR TITLE
Pointing pattern to a file rather than a folder so it can load on ServerlessLand

### DIFF
--- a/dotnet-test-samples/apigw-lambda-ddb/metadata.json
+++ b/dotnet-test-samples/apigw-lambda-ddb/metadata.json
@@ -14,11 +14,11 @@
         },
         {
             "title": "Unit Tests",
-            "filepath": "/tests/ApiTests.UnitTest/ApiTests.UnitTest"
+            "filepath": "/tests/ApiTests.UnitTest/FunctionTest.cs"
         },
         {
             "title": "Integration Test",
-            "filepath": "/tests/ApiTests.IntegrationTest"
+            "filepath": "/tests/ApiTests.IntegrationTest/IntegrationTest.cs"
         }        
     ],
     "authors": [


### PR DESCRIPTION
Trying to import this pattern but it is failing due to missing files, this PR will fix that by being explicit to which file will be loaded on the UI.

@jeastham1993 happy with the files I selected here?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
