### PR TITLE
Adding github_repo_url to files missing them

### DIFF
--- a/dotnet-test-samples/apigw-lambda-ddb/metadata.json
+++ b/dotnet-test-samples/apigw-lambda-ddb/metadata.json
@@ -5,6 +5,7 @@
     "language": "CSharp",
     "type": ["Unit", "Integration"],
     "diagram": "../docs/apigw-lambda-ddb.jpg",
+    "git_repo_url": "https://github.com/aws-samples/serverless-test-samples",
     "framework": "SAM",
     "services": ["apigw", "lambda", "dynamodb"],
     "pattern_detail_tabs": [

--- a/dotnet-test-samples/apigw-lambda-list-s3-buckets/metadata.json
+++ b/dotnet-test-samples/apigw-lambda-list-s3-buckets/metadata.json
@@ -5,6 +5,7 @@
     "language": "CSharp",
     "type": ["Unit", "Integration"],
     "diagram": "../docs/apigw-lambda-list-s3-buckets.png",
+    "git_repo_url": "https://github.com/aws-samples/serverless-test-samples",
     "framework": "SAM",
     "services": ["apigw", "lambda", "s3"],
     "pattern_detail_tabs": [

--- a/dotnet-test-samples/hexagonal-architecture/metadata.json
+++ b/dotnet-test-samples/hexagonal-architecture/metadata.json
@@ -5,6 +5,7 @@
     "language": "CSharp",
     "type": ["Unit", "Integration"],
     "diagram": "../docs/hexagonal-architecture.png.png",
+    "git_repo_url": "https://github.com/aws-samples/serverless-test-samples",
     "framework": "SAM",
     "services": ["apigw", "lambda", "dynamoDB"],
     "pattern_detail_tabs": [


### PR DESCRIPTION
Adding `"git_repo_url"` to metadata files that are missing them, when this is present, serverless land will render the GitHub repo for users to click on and continue to explore. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
