### PR TITLE
Diagram needs to be a string not an array

### DIFF
--- a/typescript-test-samples/schema-and-contract-testing/metadata.json
+++ b/typescript-test-samples/schema-and-contract-testing/metadata.json
@@ -4,7 +4,7 @@
   "content_language": "English",
   "language": "TypeScript",
   "type": ["Unit"],
-  "diagram": ["/img/schema_testing.png", "/img/contract_testing.png"],
+  "diagram": "/img/schema_testing.png",
   "git_repo_url": "https://github.com/aws-samples/serverless-test-samples",
   "pattern_source": "AWS",
   "pattern_detail_tabs": [


### PR DESCRIPTION
Serverless land uses the diagram to render the thumbnail on the pattern, needs to be a string not an array, no way to support multiple thumbnails at the moment.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
