### PR TITLE
Tag contract testing with EventBridge service for search

### DIFF
--- a/typescript-test-samples/schema-and-contract-testing/metadata.json
+++ b/typescript-test-samples/schema-and-contract-testing/metadata.json
@@ -4,6 +4,9 @@
   "content_language": "English",
   "language": "TypeScript",
   "type": ["Unit"],
+  "services": [
+        "eventbridge"
+   ],
   "diagram": "/img/schema_testing.png",
   "git_repo_url": "https://github.com/aws-samples/serverless-test-samples",
   "pattern_source": "AWS",


### PR DESCRIPTION
I would like to tag this testing pattern so search works on serverless land, customers can search eventbridge testing patterns and come across this.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
