### PR TITLE
Update metadata.json

### DIFF
--- a/typescript-test-samples/apigw-lambda-sqs-sns-datadog/metadata.json
+++ b/typescript-test-samples/apigw-lambda-sqs-sns-datadog/metadata.json
@@ -3,7 +3,7 @@
   "description": "This example is about testing API Gateway, SNS, SQS, and Lambda with Synthetic API Tests and Monitors. It uses Datadog Synthetic Testing and Monitoring to add logging, metrics, distributed tracing,  and profiling.",
   "content_language": "English",
   "language": "TypeScript",
-  "type": ["Integration","Synthetic"],
+  "type": ["Integration"],
   "diagram": "/images/architecture.png",
   "framework": "CDK",
   "services": ["lambda","sqs","sns","apigw"],
@@ -17,10 +17,6 @@
       {
           "title": "Worker",
           "filepath": "/resources/worker.ts"
-      },
-      {
-          "title": "Synthetic Testing",
-          "filepath": "/README.md#synthetic-testing"
       }
   ],
   "authors": [


### PR DESCRIPTION
Serverless Land does not support README injection in the paths also the type Synthetic is not supported for the metadata/filters.

