### PR TITLE
Kinesis-lambda-dynamodb - Invalid metadata

### DIFF
--- a/python-test-samples/kinesis-lambda-dynamodb/metadata.json
+++ b/python-test-samples/kinesis-lambda-dynamodb/metadata.json
@@ -4,7 +4,7 @@
     "content_language": "English",
     "language": "Python",
     "type": ["Unit", "Integration"],
-    "diagram": ["/img/unit-test-description.png", "/img/system-under-test.png"],
+    "diagram": "/img/unit-test-description.png",
     "framework": "SAM",
     "services": ["kinesis", "lambda", "dynamodb"],
     "git_repo_url": "https://github.com/aws-samples/serverless-test-samples",


### PR DESCRIPTION
Quick fix for the metadata for ServerlessLand, the website is failing to process this file as it expects only one image to render on the pattern, removing the array and replacing it with one image to use. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
