### PR TITLE
Add AWS_DEFAULT_REGION to Makefile

### DIFF
--- a/python-test-samples/lambda-mock/Makefile
+++ b/python-test-samples/lambda-mock/Makefile
@@ -1,4 +1,5 @@
 PIP ?= pip3
+export AWS_DEFAULT_REGION=us-east-1
 
 target:
 	$(info ${HELP_MESSAGE})


### PR DESCRIPTION
Test and coverage fails without default region in ~/.aws/config

```
File ".../src/sample_lambda/app.py", line 19, in <module>
    _LAMBDA_DYNAMODB_RESOURCE = { "resource" : resource('dynamodb'),
                                              ^^^^^^^^^^^^^^^^^^^^
...
botocore.exceptions.NoRegionError: You must specify a region.
```

Fixing it by adding AWS_DEFAULT_REGION to Makefile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
