### PR TITLE
Adjust link since plugin_tester README file doesn't exist

### DIFF
--- a/python-test-samples/integrated-application-test-kit/README.md
+++ b/python-test-samples/integrated-application-test-kit/README.md
@@ -35,7 +35,7 @@ This sample is built around the idea of a Video Plugin application where users m
 
 ![Architecture](./img/architecture.png)
 
-The system includes a [plugin tester](./plugins/plugin_tester/README.md), which is an AWS Step Functions workflow that acts as the video platform - emitting lifecycle events with the expected structure and sequence. [The sample tests](./plugins/2-postvalidate-plugins/python-minimal-plugin/tests/) integrate with the plugin tester to exercise plugin functionality.
+The system includes a [plugin tester](./plugins/plugin_tester/), which is an AWS Step Functions workflow that acts as the video platform - emitting lifecycle events with the expected structure and sequence. [The sample tests](./plugins/2-postvalidate-plugins/python-minimal-plugin/tests/) integrate with the plugin tester to exercise plugin functionality.
 
 ![Plugin Tester](./img/plugin_tester_1.png)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adjusts link to `plugin_tester` since there's not a README file there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
