### PR TITLE
Upgrating python apigw-lambda test to python 3.13

### DIFF
--- a/python-test-samples/apigw-lambda/README.md
+++ b/python-test-samples/apigw-lambda/README.md
@@ -1,4 +1,4 @@
-[![python: 3.9](https://img.shields.io/badge/Python-3.9-green)](https://img.shields.io/badge/Python-3.9-green)
+[![python: 3.13](https://img.shields.io/badge/Python-3.13-green)](https://img.shields.io/badge/Python-3.13-green)
 [![AWS: Lambda](https://img.shields.io/badge/AWS-Lambda-blueviolet)](https://img.shields.io/badge/AWS-Lambda-blueviolet)
 [![test: unit](https://img.shields.io/badge/Test-Unit-blue)](https://img.shields.io/badge/Test-Unit-blue)
 [![test: integration](https://img.shields.io/badge/Test-Integration-yellow)](https://img.shields.io/badge/Test-Integration-yellow)
@@ -45,7 +45,7 @@ The SAM CLI extends the AWS CLI that adds functionality for building and testing
 To use the SAM CLI, you need the following tools.
 
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* Python 3 - [Install Python 3](https://www.python.org/downloads/)
+* Python 3.13 - [Install Python 3.13](https://www.python.org/downloads/)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 [[top]](#python-test-samples-project)
@@ -172,11 +172,15 @@ The project uses the [moto](http://docs.getmoto.org/en/latest/) dependency libra
 # Create and Activate a Python Virtual Environment
 
 pip3 install virtualenv
-python3 -m venv venv
+python3 -m virtualenv venv
 source ./venv/bin/activate
 
-# install dependencies
+# Verify Python version (Should show Python 3.13.x)
 
+python3 --version
+pip3 --version
+
+# install dependencies
 pip3 install -r tests/requirements.txt
 
 # run unit tests with mocks
@@ -202,7 +206,7 @@ The `AWS CLI` enables you to invoke a Lambda function in the cloud.
 ```shell
 # invoke a Lambda function in the cloud using the AWS CLI.  Substitute the function name as created in your stack.
 
-aws lambda invoke --function-name apigw-lambda-PythonTestDemo-6Ecinx8IauZv outfile.txt
+aws lambda invoke --function-name apigw-lambda-PythonTestDemo-XlkJiaHvJn1t outfile.txt
 ```
 [[top]](#python-test-samples-project)
 
@@ -218,7 +222,7 @@ sam logs -n PythonTestDemo --stack-name apigw-lambda --tail
 In a new terminal, curl the API Gateway and watch the log output.
 
 ```shell
-curl <API Gateway url>
+curl https://<API Gateway deploy>.execute-api.eu-west-1.amazonaws.com/Prod/hello
 ```
 
 You can find more information and examples about filtering Lambda function logs in the [SAM CLI Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-logging.html).

--- a/python-test-samples/apigw-lambda/template.yaml
+++ b/python-test-samples/apigw-lambda/template.yaml
@@ -22,7 +22,7 @@ Resources:
               Resource: 'arn:aws:s3:::*'
       CodeUri: src/
       Handler: app.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.13
       Architectures:
         - x86_64
       Events:

--- a/python-test-samples/apigw-lambda/tests/unit/mock_test.py
+++ b/python-test-samples/apigw-lambda/tests/unit/mock_test.py
@@ -5,7 +5,7 @@ import json
 from urllib import response
 import boto3
 import pytest
-from moto import mock_s3
+from moto import mock_aws  # Changed from mock_s3
 from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
 from src import app
 
@@ -16,11 +16,11 @@ def apigw_event() ->  APIGatewayProxyEvent:
         return APIGatewayProxyEvent(json.load(f))
 
 
-@mock_s3
+@mock_aws  # Changed from @mock_s3
 def test_lambda_handler(apigw_event: dict) -> None:
 
     # set up test bucket
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client('s3', region_name='us-east-1')  # Added region for consistency
     test_bucket_names = ["test_bucket1","test_bucket2"]
     test_data = b'col_1,col_2\n1,2\n3,4\n'
     for test_bucket_name in test_bucket_names:


### PR DESCRIPTION
*Description of changes:*
Upgrating python apigw-lambda test from deprecated python 3.9 to latest python 3.13
