### PR TITLE
Upgrating python apigw-lambda-layer to python 3.13

### DIFF
--- a/python-test-samples/apigw-lambda-layer/README.md
+++ b/python-test-samples/apigw-lambda-layer/README.md
@@ -1,4 +1,4 @@
-[![python: 3.9](https://img.shields.io/badge/Python-3.9-green)](https://img.shields.io/badge/Python-3.9-green)
+[![python: 3.13](https://img.shields.io/badge/Python-3.13-green)](https://img.shields.io/badge/Python-3.13-green)
 [![AWS: Lambda](https://img.shields.io/badge/AWS-Lambda-blueviolet)](https://img.shields.io/badge/AWS-Lambda-blueviolet)
 [![test: unit](https://img.shields.io/badge/Test-Unit-blue)](https://img.shields.io/badge/Test-Unit-blue)
 
@@ -97,11 +97,16 @@ To run the unit tests:
 ```shell
 
 # Run from the project directory serverless-test-samples/python-test-samples/apigw-lambda-layer
-# install dependencies
+# Verify Python version (Should show Python 3.13.x)
 
+python3 --version
+pip3 --version
+
+# Create and Activate a Python Virtual Environment
+# One-time setup
 pip3 install virtualenv
-python3 -m venv venv
-source venv/bin/activate
+python3 -m virtualenv venv
+source ./venv/bin/activate
 pip3 install -r tests/requirements.txt
 
 # run Lambda layer unit tests with mocks

--- a/python-test-samples/apigw-lambda-layer/template.yaml
+++ b/python-test-samples/apigw-lambda-layer/template.yaml
@@ -5,7 +5,7 @@ Description: SAM Template for apigw-lambda-layer
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-      Runtime: python3.9
+      Runtime: python3.13
       Timeout: 30
       Architectures:
         - arm64
@@ -17,7 +17,7 @@ Resources:
     Type: 'AWS::Serverless::LayerVersion'
     Properties:
       CompatibleRuntimes:
-        - python3.9
+        - python3.13
       ContentUri: src/sampleCodeLayer
       Description: Common code layer
       LayerName: !Sub "${AWS::StackName}-CodeLayer"
@@ -26,7 +26,7 @@ Resources:
     Type: 'AWS::Serverless::LayerVersion'
     Properties:
       CompatibleRuntimes:
-        - python3.9
+        - python3.13
       ContentUri: src/sampleSchemaLayer
       Description: Common schema (API contract) layer
       LayerName: !Sub "${AWS::StackName}-SchemaLayer"    
@@ -68,4 +68,3 @@ Outputs:
   PythonTestDemoIamRole:
     Description: "Implicit IAM Role created for Hello World function"
     Value: !GetAtt PythonTestDemoRole.Arn
-

--- a/python-test-samples/apigw-lambda-layer/tests/requirements.txt
+++ b/python-test-samples/apigw-lambda-layer/tests/requirements.txt
@@ -1,7 +1,7 @@
-pytest
-pytest-mock
-boto3
-moto
-aws_lambda_powertools
-aws-xray-sdk
-fastjsonschema
+pytest>=7.0.0
+pytest-mock>=3.10.0
+boto3>=1.26.0
+moto>=4.0.0
+aws_lambda_powertools>=2.0.0
+aws-xray-sdk>=2.12.0
+fastjsonschema>=2.16.0

--- a/python-test-samples/apigw-lambda-layer/tests/unit/mock_test_samplecodelayer.py
+++ b/python-test-samples/apigw-lambda-layer/tests/unit/mock_test_samplecodelayer.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: MIT-0
 
 import boto3
-from moto import mock_s3
+from moto import mock_aws  # Changed from mock_s3
 from src.sampleCodeLayer.python.layer import get_s3_bucket_list_as_string
 
-@mock_s3
+@mock_aws  # Changed from @mock_s3
 def test_get_s3_bucket_list_as_string() -> None:
 
     # set up test bucket
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client('s3', region_name='us-east-1')  # Added region for consistency
     test_bucket_names = ["test_bucket1","test_bucket2"]
     test_data = b'col_1,col_2\n1,2\n3,4\n'
     for test_bucket_name in test_bucket_names:


### PR DESCRIPTION
*Description of changes:*
Upgrading python test apigw-lambda-layer from deprecated 3.9 to python 3.13

