### PR TITLE
Upgrating python test apigw-sqs-lambda-sqs to python 3.13

### DIFF
--- a/python-test-samples/apigw-sqs-lambda-sqs/README.md
+++ b/python-test-samples/apigw-sqs-lambda-sqs/README.md
@@ -1,4 +1,4 @@
-[![python: 3.9](https://img.shields.io/badge/Python-3.9-green)](https://img.shields.io/badge/Python-3.9-green)
+[![python: 3.13](https://img.shields.io/badge/Python-3.13-green)](https://img.shields.io/badge/Python-3.13-green)
 [![AWS: SQS](https://img.shields.io/badge/AWS-SQS-blueviolet)](https://img.shields.io/badge/AWS-SQS-blueviolet)
 [![test: integration](https://img.shields.io/badge/Test-Integration-yellow)](https://img.shields.io/badge/Test-Integration-yellow)
 
@@ -60,9 +60,9 @@ The SAM CLI extends the AWS CLI that adds functionality for building and testing
 To use the SAM CLI, you need the following tools.
 
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* Python 3.9 and above - [Install Python 3.9](https://www.python.org/downloads/)
+* Python 3.13 and above - [Install Python 3.13](https://www.python.org/downloads/)
 
-    In case you are using AWS cloud9, currently the default Python version is 3.7. you can check [here](https://repost.aws/questions/QU14iutbqtSsm1gHwQwt02pA/upgrade-to-python-3-9-on-cloud-9) how to update it.
+     In case you are using AWS cloud9, you may need to upgrade to Python 3.13. You can check [here](https://repost.aws/questions/QU14iutbqtSsm1gHwQwt02pA/upgrade-to-python-3-9-on-cloud-9) for guidance on upgrading Python versions.
 
 
 
@@ -112,10 +112,10 @@ To run the integration test, create the environment variable "AWS_SAM_STACK_NAME
 export AWS_SAM_STACK_NAME=<stack-name>
 export AWS_DEFAULT_REGION=<region-of-test>
 pip3 install virtualenv
-python3 -m venv venv
+python3 -m virtualenv venv
 source venv/bin/activate
 pip3 install -r tests/requirements.txt 
-python3 -m pytest -s tests/integration -v 
+python3 -m pytest -s tests/integration -v
 
 # For INFO debug log you can run: python -m pytest -s tests/integration --log-cli-level=20
 ```

--- a/python-test-samples/apigw-sqs-lambda-sqs/template.yaml
+++ b/python-test-samples/apigw-sqs-lambda-sqs/template.yaml
@@ -102,7 +102,7 @@ Resources:
         - AmazonSQSFullAccess
       CodeUri: src/process-input-queue
       Handler: process_input_queue.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.13  # Changed from python3.9
       Environment:
         Variables:
           OUTPUT_QUEUE_NAME: !Ref OutputQueue
@@ -120,7 +120,7 @@ Resources:
     Properties:
       CodeUri: src/write-test-result
       Handler: write_test_result.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.13  # Changed from python3.9
       MemorySize: 128
       Timeout: 5
       Tracing: Active

--- a/python-test-samples/apigw-sqs-lambda-sqs/tests/requirements.txt
+++ b/python-test-samples/apigw-sqs-lambda-sqs/tests/requirements.txt
@@ -1,5 +1,5 @@
-pytest
-boto3
+pytest>=7.0.0
+boto3>=1.26.0
 moto
 uuid
-requests
+requests>=2.28.0


### PR DESCRIPTION
*Description of changes:*
upgrading python test example apigw-sqs-lambda-sqs from deprecated python 3.9 to lastest python 3.13