### PR TITLE
Replaced mocked services with mock_aws

### DIFF
--- a/python-test-samples/apigw-lambda-dynamodb/tests/unit/mock_test.py
+++ b/python-test-samples/apigw-lambda-dynamodb/tests/unit/mock_test.py
@@ -17,7 +17,7 @@ import moto
 from src import app
 
 # Mock the DynamoDB Service during the test
-@moto.mock_dynamodb
+@moto.mock_aws
 
 class TestSampleLambdaWithDynamoDB(TestCase):
     """

--- a/python-test-samples/apigw-lambda-layer/tests/unit/mock_test_samplecodelayer.py
+++ b/python-test-samples/apigw-lambda-layer/tests/unit/mock_test_samplecodelayer.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: MIT-0
 
 import boto3
-from moto import mock_s3
+from moto import mock_aws
 from src.sampleCodeLayer.python.layer import get_s3_bucket_list_as_string
 
-@mock_s3
+@mock_aws
 def test_get_s3_bucket_list_as_string() -> None:
 
     # set up test bucket
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client('s3', region_name='us-east-1')
     test_bucket_names = ["test_bucket1","test_bucket2"]
     test_data = b'col_1,col_2\n1,2\n3,4\n'
     for test_bucket_name in test_bucket_names:

--- a/python-test-samples/apigw-lambda/tests/unit/mock_test.py
+++ b/python-test-samples/apigw-lambda/tests/unit/mock_test.py
@@ -5,7 +5,7 @@ import json
 from urllib import response
 import boto3
 import pytest
-from moto import mock_s3
+from moto import mock_aws
 from aws_lambda_powertools.utilities.data_classes import APIGatewayProxyEvent
 from src import app
 
@@ -16,11 +16,11 @@ def apigw_event() ->  APIGatewayProxyEvent:
         return APIGatewayProxyEvent(json.load(f))
 
 
-@mock_s3
+@mock_aws
 def test_lambda_handler(apigw_event: dict) -> None:
 
     # set up test bucket
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client('s3', region_name='us-east-1')
     test_bucket_names = ["test_bucket1","test_bucket2"]
     test_data = b'col_1,col_2\n1,2\n3,4\n'
     for test_bucket_name in test_bucket_names:

--- a/python-test-samples/kinesis-lambda-dynamodb/tests/unit/mock_test.py
+++ b/python-test-samples/kinesis-lambda-dynamodb/tests/unit/mock_test.py
@@ -15,8 +15,8 @@ from boto3 import Session
 from boto3.dynamodb.conditions import Key
 import moto
 
-# Mock the DynamoDB Service during the test
-@moto.mock_dynamodb
+# Mock all AWS Services 
+@moto.mock_aws
 class TestKinesisLambdaWithDynamoDB(TestCase):
     """
     Unit Test class for src/app.py

--- a/python-test-samples/lambda-mock/tests/unit/src/test_sample_lambda.py
+++ b/python-test-samples/lambda-mock/tests/unit/src/test_sample_lambda.py
@@ -20,9 +20,8 @@ from src.sample_lambda.app import LambdaDynamoDBClass, LambdaS3Class   # pylint:
 from src.sample_lambda.app import lambda_handler, create_letter_in_s3  # pylint: disable=wrong-import-position
 from src.sample_lambda.schemas import INPUT_SCHEMA                     # pylint: disable=wrong-import-position
 
-# [1] Mock all AWS Services in use
-@moto.mock_dynamodb
-@moto.mock_s3
+# [1] Mock all AWS Services 
+@moto.mock_aws
 class TestSampleLambda(TestCase):
     """
     Test class for the application sample AWS Lambda Function

--- a/workshops/serverless-testing-workshop/tests/unit/src/test_checkout.py
+++ b/workshops/serverless-testing-workshop/tests/unit/src/test_checkout.py
@@ -27,8 +27,8 @@ from schemas import OUTPUT_SCHEMA                     # pylint: disable=wrong-im
 # Import the handler under test
 import app
 
-# Mock the DynamoDB Service during the test
-@moto.mock_dynamodb
+# Mock all AWS Services 
+@moto.mock_aws
 
 
 class TestSampleLambdaWithDynamoDB(TestCase):


### PR DESCRIPTION
*Issue #, if available:* #398

*Description of changes:*

Replaced moto calls from mock_*service* to mock_aws to replace the depreciated syntax.  See https://github.com/getmoto/moto/blob/master/CHANGELOG.md#500

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
