### PR TITLE
Upgrating async-lambda-dynamodb test to python 3.13

### DIFF
--- a/python-test-samples/async-lambda-dynamodb/Makefile
+++ b/python-test-samples/async-lambda-dynamodb/Makefile
@@ -9,13 +9,14 @@ clean: ##=> Deletes current build environment and latest build
 	rm -rf ./.aws-sam/ ./venv/
 
 checkOSDependencies:
-	python3 --version || grep "3.9" || (echo "Error: Requires Python 3.9" && exit 1)
+	python3 --version | grep "3.13" || (echo "Error: Requires Python 3.13" && exit 1)
 
 all: clean build
 
 install: checkOSDependencies
 	${PIP} install virtualenv
-	python3 -m venv venv
+	python3 -m virtualenv venv
+	source venv/bin/activate && ${PIP} install pytest boto3 backoff
 
 deps:
 	source ./venv/bin/activate && ${PIP} install -r tests/integration/requirements.txt

--- a/python-test-samples/async-lambda-dynamodb/README.md
+++ b/python-test-samples/async-lambda-dynamodb/README.md
@@ -29,7 +29,7 @@ The SAM CLI is an extension of the AWS CLI that adds functionality for building 
 To use the SAM CLI, you need the following tools.
 
 - SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-- Python 3 - [Install Python 3](https://www.python.org/downloads/)
+- Python 3.13 - [Install Python 3.13](https://www.python.org/downloads/)
 - Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 
 This project uses the `make` build automation tool to provide convenient commands for building, deploying and testing this sample application. To view the available commands make sure this utility is installed and run the `make` command in the terminal from the same directory as the `Makefile`.
@@ -72,3 +72,4 @@ Run these four commands in sequence.
 - `exit`        - Close the virtual environment shell
 
 [[top]](#asynchronous-integration-test-with-lambda-event-listener-and-dynamodb)
+

--- a/python-test-samples/async-lambda-dynamodb/template.yaml
+++ b/python-test-samples/async-lambda-dynamodb/template.yaml
@@ -20,12 +20,12 @@ Globals: # https://docs.aws.amazon.com/serverless-application-model/latest/devel
     Function:
         Timeout: 15
         MemorySize: 256
-        Runtime: python3.9
+        Runtime: python3.13
         Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
         # Embed Lambda Powertools as a shared Layer
         # See: https://awslabs.github.io/aws-lambda-powertools-python/latest/#lambda-layer
         Layers: # 
-            - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:9
+            - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPython:76
         Environment:
             Variables:
                 DESTINATION_BUCKET: 
@@ -160,6 +160,5 @@ Outputs:
       Condition: CreateTestResources
       Description: "DynamoDB table to persist test results"
       Value: !Ref AsyncTransformTestResultsTable
-
 
 


### PR DESCRIPTION
*Description of changes:*
Upgrating python async-lambda-dynamodb test from deprecated python 3.9 to latest python 3.13