### PR TITLE
Upgrating lambda-mock python test to python 3.13

### DIFF
--- a/python-test-samples/lambda-mock/Makefile
+++ b/python-test-samples/lambda-mock/Makefile
@@ -9,7 +9,7 @@ clean: ##=> Deletes current build environment and latest build
 	rm -rf ./.aws-sam/ ./venv/
 
 checkOSDependencies:
-	python3 --version || grep "3.9" || (echo "Error: Requires Python 3.9" && exit 1)
+	python3 --version | grep "3.13" || (echo "Error: Requires Python 3.13" && exit 1)
 
 all: clean build
 

--- a/python-test-samples/lambda-mock/README.md
+++ b/python-test-samples/lambda-mock/README.md
@@ -1,4 +1,4 @@
-[![python: 3.9](https://img.shields.io/badge/Python-3.9-green)](https://img.shields.io/badge/Python-3.9-green)
+[![python: 3.13](https://img.shields.io/badge/Python-3.13-green)](https://img.shields.io/badge/Python-3.13-green)
 [![AWS: DynamoDB](https://img.shields.io/badge/AWS-DynamoDB-blueviolet)](https://img.shields.io/badge/AWS-DynamoDB-blueviolet)
 [![AWS: S#](https://img.shields.io/badge/AWS-S3-green)](https://img.shields.io/badge/AWS-AWS-S3-green)
 [![test: unit](https://img.shields.io/badge/Test-Unit-blue)](https://img.shields.io/badge/Test-Unit-blue)
@@ -70,14 +70,14 @@ This pattern can be used with a variety of infrastructure as code systems includ
 
 The code in this project is simplified - we’ve opted for concise snippets over fully completed or PEP8 compliant production code.
 
-[Top](#contents)
+[Top](#contents)x
 
 ---
 ## Prerequisites
 
 * [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 * [AWS Serverless Application Model (SAM) CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* [Python 3.9](https://www.python.org/downloads/)
+* [Python 3.13](https://www.python.org/downloads/)
 * [Make build utility](https://www.gnu.org/software/make/)
 
 [Top](#contents)
@@ -100,6 +100,7 @@ The project Makefile contains helper commands for working with the project:
 
 ## Running the project
 
+* Setting default region: export AWS_DEFAULT_REGION=us-east-1
 * First, create the Python Virtual Environment by using the ```make install``` command.
 * Run the unit tests with the ```make test``` command.
 * To (optionally) deploy the project, use the ```make deploy.g``` command.

--- a/python-test-samples/lambda-mock/template.yaml
+++ b/python-test-samples/lambda-mock/template.yaml
@@ -56,7 +56,7 @@ Resources:
     Properties:
       CodeUri: ./src/sample_lambda/
       Handler: app.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.13
       MemorySize: 256
       Architectures:
       - arm64

--- a/python-test-samples/lambda-mock/tests/unit/src/test_sample_lambda.py
+++ b/python-test-samples/lambda-mock/tests/unit/src/test_sample_lambda.py
@@ -11,7 +11,7 @@ import json
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from boto3 import resource, client
-import moto
+from moto import mock_aws  # Changed from import moto
 from aws_lambda_powertools.utilities.validation import validate
 
 # [0] Import the Globals, Classes, Schemas, and Functions from the Lambda Handler
@@ -21,8 +21,7 @@ from src.sample_lambda.app import lambda_handler, create_letter_in_s3  # pylint:
 from src.sample_lambda.schemas import INPUT_SCHEMA                     # pylint: disable=wrong-import-position
 
 # [1] Mock all AWS Services in use
-@moto.mock_dynamodb
-@moto.mock_s3
+@mock_aws  # Changed from @moto.mock_dynamodb @moto.mock_s3
 class TestSampleLambda(TestCase):
     """
     Test class for the application sample AWS Lambda Function


### PR DESCRIPTION
*Description of changes:*
Upgrating python lambda-mock test from deprecated python 3.9 to latest python 3.13
