### PR TITLE
Upgrating schema-and-contract-testing python test to python 3.13

### DIFF
--- a/python-test-samples/schema-and-contract-testing/README.md
+++ b/python-test-samples/schema-and-contract-testing/README.md
@@ -1,4 +1,4 @@
-[![python: 3.9](https://img.shields.io/badge/Python-3.9-green)](https://img.shields.io/badge/Python-3.11-green)
+[![python: 3.13](https://img.shields.io/badge/Python-3.13-green)](https://img.shields.io/badge/Python-3.13-green)
 [![test: unit](https://img.shields.io/badge/Test-Unit-blue)](https://img.shields.io/badge/Test-Unit-blue)
 
 # Python: Schema and Contract Testing for Event-Driven Architectures
@@ -116,7 +116,7 @@ In order to detect breaking changes using schema testing, we will generate an ev
 Create a virtual environment and install the dependencies.
 
 ```shell
-python3 -m venv .venv
+python3 -m virtualenv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```

--- a/python-test-samples/schema-and-contract-testing/requirements.txt
+++ b/python-test-samples/schema-and-contract-testing/requirements.txt
@@ -1,6 +1,6 @@
 iniconfig==2.0.0
 packaging==23.1
 pluggy==1.0.0
-pydantic==1.10.13
-pytest==7.3.1
-typing_extensions==4.5.0
+pydantic>=2.5.0
+pytest>=7.4.0
+typing-extensions>=4.8.0

--- a/python-test-samples/schema-and-contract-testing/src/customer_v1_0_0_with_validation.py
+++ b/python-test-samples/schema-and-contract-testing/src/customer_v1_0_0_with_validation.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class Customer(BaseModel):
@@ -17,9 +17,10 @@ class Customer(BaseModel):
         ..., examples=['2 Park St, Sydney, NSW 2000, Australia'], title='Address'
     )
 
-    @validator('address')
-    def address_has_four_fields(cls, address_value):
-        """Fucntion to validate address field"""
-        if len(address_value.split(',')) != 4:
+    @field_validator('address', mode='before')
+    @classmethod
+    def address_has_four_fields(cls, address_value: str) -> str:
+        """Function to validate address field"""
+        if isinstance(address_value, str) and len(address_value.split(',')) != 4:
             raise ValueError("Address must have four fields separated by ','.")
         return address_value

--- a/python-test-samples/schema-and-contract-testing/tests/test_schema.py
+++ b/python-test-samples/schema-and-contract-testing/tests/test_schema.py
@@ -41,9 +41,11 @@ def test_removing_required_element_not_backward_compatible():
     with pytest.raises(Exception) as e_info:
         customer = instantiate_customer("1.3.0")
     assert e_info.type == ValidationError
-    assert "field required" in str(e_info.value)
-    assert "firstName" in str(e_info.value)
-    assert "lastName" in str(e_info.value)
+    # Updated for Pydantic v2 error message format
+    error_message = str(e_info.value)
+    assert "Field required" in error_message  # Pydantic v2 uses "Field required"
+    assert "firstName" in error_message
+    assert "lastName" in error_message
 
 
 def test_changing_business_logic_existing_field_backward_compatible():


### PR DESCRIPTION
*Description of changes:*
Upgrating python schema-and-contract-testing test from deprecated python 3.9 to latest python 3.13